### PR TITLE
changed defaultContentLanguageInSubdir

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -4,7 +4,7 @@ languageCode = 'en-us'
 # Language settings
 contentDir = "content/en"
 defaultContentLanguage = "en"
-defaultContentLanguageInSubdir = false
+defaultContentLanguageInSubdir = true
 # Useful when translating.
 enableMissingTranslationPlaceholders = true
 


### PR DESCRIPTION
# Description

changed defaultContentLanguageInSubdir to true, all english webpages are now moved to  / => /en/

## Type of change

Please delete options that are not relevant.

- [X] Design or organisational change

# Checklist:

## Documentation
- [X] My documentation follows the style, formatting and structure guidelines of this project ( [Styling-Guideline](guidelines/20-styling.md) )
- [X] I have performed a self-review of my own documentation ( [General-Guide](guidelines/10-general.md) )

## Technical
- [X] I have performed a self-review of my changes
- [X] My changes generate no new warnings
- [X] New and existing tests pass locally with my changes