### PR TITLE
Move timeout parameter to top of hugo.toml

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,5 @@
 baseURL = 'https://docs.plusserver.com/'
+timeout = "1s"
 
 # Language settings
 contentDir = "content/en"
@@ -235,7 +236,7 @@ desc = "plusserver gmbh Legal notice"
 
 
 theme = ["github.com/google/docsy", "github.com/google/docsy/dependencies"]
-timeout = "120s"
+
 
 [module]
 proxy = "direct"

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,5 @@
 baseURL = 'https://docs.plusserver.com/'
-timeout = "1s"
+timeout = "120s"
 
 # Language settings
 contentDir = "content/en"


### PR DESCRIPTION
Thers seems to be some issue with where timeout is specified in hugo.toml. This should fix it.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation update
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Design or organisational change

# Checklist:

## Documentation
- [X] My documentation follows the style, formatting and structure guidelines of this project ( [Styling-Guideline](guidelines/20-styling.md) )
- [X] I have performed a self-review of my own documentation ( [General-Guide](guidelines/10-general.md) )

## Technical
- [X] I have performed a self-review of my changes
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing tests pass locally with my changes