### PR TITLE
Headlines without underlining

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -66,3 +66,10 @@ img {
     border-color: #009bf4;
 }
 
+.entry a {
+    text-decoration: none;
+}
+
+.entry a:hover {
+    text-decoration: underline;
+}


### PR DESCRIPTION
Switching to the latest Docsy release introduced underlines for the entry links on list pages. We want to stay with the previous design, where there were no headlines and only show underlines when the links are hovered over.

## Type of change

Please delete options that are not relevant.

- [X] Design or organisational change

# Checklist:

## Documentation
- [X] My documentation follows the style, formatting and structure guidelines of this project ( [Styling-Guideline](guidelines/20-styling.md) )
- [X] I have performed a self-review of my own documentation ( [General-Guide](guidelines/10-general.md) )

## Technical
- [X] I have performed a self-review of my changes
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing tests pass locally with my changes