### PR TITLE
fix: repair source link to second example

### DIFF
--- a/content/de/compute/pluscloudopen/tutorials/terraform/more/_index.md
+++ b/content/de/compute/pluscloudopen/tutorials/terraform/more/_index.md
@@ -56,7 +56,7 @@ Weitere Informationen zur Verwendung von cloud-init finden Sie in den Beispielen
 
 In diesem Beispiel deployen wir eine bestimmte Anzahl an Servern die mit ein Load Balancer Erreichbar gemacht werden.
 
-[SOURCE](https://cloudinit.readthedocs.io/en/latest/reference/examples.html)
+[SOURCE](https://github.com/pluscloudopen/terraform-pco/tree/main/loadbalancer-webservice)
 
 ### Variablen
 


### PR DESCRIPTION
The source link, wrongfully linked to cloud init documentation instead of the second example.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

## Documentation
- [x] My documentation follows the style, formatting and structure guidelines of this project ( [Styling-Guideline](guidelines/20-styling.md) )
- [x] I have performed a self-review of my own documentation ( [General-Guide](guidelines/10-general.md) )

## Technical
- [x] I have performed a self-review of my changes
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes