### PR TITLE
Revert "[npm] Bump hugo-extended from 0.134.2 to 0.136.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "hugo-extended": "^0.136.2"
+        "hugo-extended": "^0.134.2"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.20",
@@ -981,9 +981,9 @@
       }
     },
     "node_modules/hugo-extended": {
-      "version": "0.136.2",
-      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.136.2.tgz",
-      "integrity": "sha512-hcQ2ZNfMChebrfpWRSpZKJlTUWYL2RfGFbVltJrStSD2d9Z5xne+yJC1YKmV7ljbgI3Jl/W8bwVPWLF8rXy5Dg==",
+      "version": "0.134.2",
+      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.134.2.tgz",
+      "integrity": "sha512-rCt3hrgYAUoGOfOnv1s4p2mID/TDHdad+FSgPtB7wVKeDOZZe0UJtlTkCzQZ4bVNHUCQb6YMDV7Dh/p3IjR3mQ==",
       "hasInstallScript": true,
       "dependencies": {
         "careful-downloader": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "hugo-extended": "^0.136.2"
+    "hugo-extended": "^0.134.2"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",


### PR DESCRIPTION
Reverts plusserver/docs#198

PR broke date format of PSKE release notes.
See PR #200 and #199.

Only merge after #200 and #199 are applied.