### PR TITLE
Revert "[npm] Bump hugo-extended from 0.140.0 to 0.141.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "hugo-extended": "^0.141.0"
+        "hugo-extended": "^0.140.0"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.20",
@@ -981,9 +981,9 @@
       }
     },
     "node_modules/hugo-extended": {
-      "version": "0.141.0",
-      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.141.0.tgz",
-      "integrity": "sha512-6GsJ7yMnny/zyabANnTo4uHmIjOcjaA+KJUcpZl7b1raUKXCi3BVwpmd6+iu5WOhFnPjgr6zSt361L68lGVt3g==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.140.0.tgz",
+      "integrity": "sha512-3e+UKV1tH/6ooAJIvFJR//k4CP0PONRqwvj2vDQ0lNzqSjWC4WeEVOhsg6WfwejuzJIMKYjXX8e62GWDte8/8A==",
       "hasInstallScript": true,
       "dependencies": {
         "careful-downloader": "^3.0.0",
@@ -995,7 +995,7 @@
         "hugo-extended": "lib/cli.js"
       },
       "engines": {
-        "node": ">=18.12"
+        "node": ">=16.14"
       }
     },
     "node_modules/ieee754": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "hugo-extended": "^0.141.0"
+    "hugo-extended": "^0.140.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",


### PR DESCRIPTION
Reverts plusserver/docs#257

Contained breaking change for docsy