### PR TITLE
Fix broken state of live documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "hugo-extended": "^0.140.0"
+        "hugo-extended": "0.139.3"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.20",
@@ -981,10 +981,11 @@
       }
     },
     "node_modules/hugo-extended": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.140.0.tgz",
-      "integrity": "sha512-3e+UKV1tH/6ooAJIvFJR//k4CP0PONRqwvj2vDQ0lNzqSjWC4WeEVOhsg6WfwejuzJIMKYjXX8e62GWDte8/8A==",
+      "version": "0.139.3",
+      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.139.3.tgz",
+      "integrity": "sha512-FiTE625Z2OcVpWEJ99KFD8LfzI8hofbjaggictZHNJkAeVXsycEGmp41EwSORM9LMtpzRTgA29XhiOODtfAOMA==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "careful-downloader": "^3.0.0",
         "log-symbols": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "hugo-extended": "^0.140.0"
+    "hugo-extended": "0.139.3"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",


### PR DESCRIPTION
# Description

This PR reverts a regression introduced by a version bump of `hugo-extended` in #250.

Details to what happened are laid out in #266.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

## Technical
- [X] I have performed a self-review of my changes