### PR TITLE
Veralteten default Volumetype in der deutschen Version angepasst

### DIFF
--- a/content/de/compute/pluscloudopen/reference/volumes-snap-back/_index.md
+++ b/content/de/compute/pluscloudopen/reference/volumes-snap-back/_index.md
@@ -57,7 +57,7 @@ Volume-Typen helfen Ihnen bei der Auswahl des richtigen Speichers für Ihre Work
 Übersicht der veralteten Volume-Typen:
 | Volume-Typ | Verschlüsselt | Lesen IOPS | Schreiben IOPS | Lesen MB/s | Schreiben MB/s |
 |----------------------|---------- |-----------|------------|-----------|------------|
-| Nein | 2500 | 2500 | 256 | 256 |
+| \_\_DEFAULT\_\_  | Nein | 2500 | 2500 | 256 | 256 |
 | LUKS | Ja | 2500 | 2500 | 256 | 256 |
 
 {{% alert title="Hinweis" color="info" %}}


### PR DESCRIPTION
# Description

The table in the german version was off one column:
![volumetype](https://github.com/user-attachments/assets/2a4dc33a-d986-4c6d-a99c-995ffa5fe1bd)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation update
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Design or organisational change

# Checklist:

## Documentation
- [X] My documentation follows the style, formatting and structure guidelines of this project ( [Styling-Guideline](guidelines/20-styling.md) )
- [X] I have performed a self-review of my own documentation ( [General-Guide](guidelines/10-general.md) )

## Technical
- [X] I have performed a self-review of my changes
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing tests pass locally with my changes