### PR TITLE
Revert "[npm] Bump hugo-extended from 0.139.3 to 0.148.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "hugo-extended": "0.148.1"
+        "hugo-extended": "0.139.3"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.21",
@@ -877,9 +877,9 @@
       }
     },
     "node_modules/hugo-extended": {
-      "version": "0.148.1",
-      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.148.1.tgz",
-      "integrity": "sha512-TF7PBrbbxm3cXXyk+N+vam7UH4xpjikXSoQsGukxbCKQAaYElCB+x1nQd3CSN0DK+xVpHEs0pB2uIPm9OAFywA==",
+      "version": "0.139.3",
+      "resolved": "https://registry.npmjs.org/hugo-extended/-/hugo-extended-0.139.3.tgz",
+      "integrity": "sha512-FiTE625Z2OcVpWEJ99KFD8LfzI8hofbjaggictZHNJkAeVXsycEGmp41EwSORM9LMtpzRTgA29XhiOODtfAOMA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -892,7 +892,7 @@
         "hugo-extended": "lib/cli.js"
       },
       "engines": {
-        "node": ">=18.12"
+        "node": ">=16.14"
       }
     },
     "node_modules/ieee754": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "hugo-extended": "0.148.1"
+    "hugo-extended": "0.139.3"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",


### PR DESCRIPTION
Reverts plusserver/docs#301

Build breaks with errors
See https://github.com/plusserver/docs/actions/runs/16261892976